### PR TITLE
Add API to validate a Flag value without setting it

### DIFF
--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -905,7 +905,7 @@ bool FlagRegistry::ValidateValueLocked(CommandLineFlag* flag, const char* value,
   delete dummy_value;
 
   if (result) {
-    // On success clear the error message.
+    // On success clear the message which says '<flag> set to <value>'.
     *err_msg = "";
   }
   return result;

--- a/src/gflags.h.in
+++ b/src/gflags.h.in
@@ -246,6 +246,8 @@ enum FlagSettingMode {
 extern GFLAGS_DLL_DECL std::string SetCommandLineOption        (const char* name, const char* value);
 extern GFLAGS_DLL_DECL std::string SetCommandLineOptionWithMode(const char* name, const char* value, FlagSettingMode set_mode);
 
+extern GFLAGS_DLL_DECL bool ValidateCommandLineOption(const char* name, const char* value, std::string* err_msg);
+
 
 // --------------------------------------------------------------------
 // Saves the states (value, default value, whether the user has set
@@ -579,7 +581,7 @@ class StringFlagDestructor {
   void *current_storage_;
   void *defvalue_storage_;
 
-public: 
+public:
 
   StringFlagDestructor(void *current, void *defvalue)
   : current_storage_(current), defvalue_storage_(defvalue) {}

--- a/src/gflags.h.in
+++ b/src/gflags.h.in
@@ -581,7 +581,7 @@ class StringFlagDestructor {
   void *current_storage_;
   void *defvalue_storage_;
 
-public:
+public: 
 
   StringFlagDestructor(void *current, void *defvalue)
   : current_storage_(current), defvalue_storage_(defvalue) {}

--- a/src/gflags_ns.h.in
+++ b/src/gflags_ns.h.in
@@ -70,6 +70,7 @@ using GFLAGS_NAMESPACE::SET_FLAG_IF_DEFAULT;
 using GFLAGS_NAMESPACE::SET_FLAGS_DEFAULT;
 using GFLAGS_NAMESPACE::SetCommandLineOption;
 using GFLAGS_NAMESPACE::SetCommandLineOptionWithMode;
+using GFLAGS_NAMESPACE::ValidateCommandLineOption;
 using GFLAGS_NAMESPACE::FlagSaver;
 using GFLAGS_NAMESPACE::CommandlineFlagsIntoString;
 using GFLAGS_NAMESPACE::ReadFlagsFromString;

--- a/src/util.h
+++ b/src/util.h
@@ -194,21 +194,22 @@ template <> struct CompileAssert<true> {};
   }
 
 // Note that this macro uses a FlagSaver to keep tests isolated.
-#define TEST(a, b)                                                                                 \
-  struct Test_##a##_##b {                                                                          \
-    Test_##a##_##b() { g_testlist.push_back(&Run); }                                               \
-    static bool Run() {                                                                            \
-      if (!FLAGS_test_filter.empty() && strcasecmp(FLAGS_test_filter.c_str(), (#a "/" #b)) != 0) { \
-        return false;                                                                              \
-      }                                                                                            \
-      FlagSaver fs;                                                                                \
-      fprintf(stderr, "Running test %s/%s\n", #a, #b);                                             \
-      RunTest();                                                                                   \
-      return true;                                                                                 \
-    }                                                                                              \
-    static void RunTest();                                                                         \
-  };                                                                                               \
-  static Test_##a##_##b g_test_##a##_##b;                                                          \
+#define TEST(a, b)                                                                        \
+  struct Test_##a##_##b {                                                                 \
+    Test_##a##_##b() { g_testlist.push_back(&Run); }                                      \
+    static bool Run() {                                                                   \
+      if (!FLAGS_test_filter.empty() && strcasecmp(FLAGS_test_filter.c_str(), #a) != 0 && \
+          strcasecmp(FLAGS_test_filter.c_str(), (#a "/" #b)) != 0) {                      \
+        return false;                                                                     \
+      }                                                                                   \
+      FlagSaver fs;                                                                       \
+      fprintf(stderr, "Running test %s/%s\n", #a, #b);                                    \
+      RunTest();                                                                          \
+      return true;                                                                        \
+    }                                                                                     \
+    static void RunTest();                                                                \
+  };                                                                                      \
+  static Test_##a##_##b g_test_##a##_##b;                                                 \
   void Test_##a##_##b::RunTest()
 
 // This is a dummy class that eases the google->opensource transition.

--- a/src/util.h
+++ b/src/util.h
@@ -178,30 +178,37 @@ template <> struct CompileAssert<true> {};
   } while (0)
 
 // Call this in a .cc file where you will later call RUN_ALL_TESTS in main().
-#define TEST_INIT                                                       \
-  static std::vector<void (*)()> g_testlist;  /* the tests to run */    \
-  static int RUN_ALL_TESTS() {                                          \
-    std::vector<void (*)()>::const_iterator it;                         \
-    for (it = g_testlist.begin(); it != g_testlist.end(); ++it) {       \
-      (*it)();   /* The test will error-exit if there's a problem. */   \
-    }                                                                   \
-    fprintf(stderr, "\nPassed %d tests\n\nPASS\n",                      \
-            static_cast<int>(g_testlist.size()));                       \
-    return 0;                                                           \
+#define TEST_INIT                                                   \
+  static std::vector<bool (*)()> g_testlist; /* the tests to run */ \
+  static int RUN_ALL_TESTS() {                                      \
+    std::vector<bool (*)()>::const_iterator it;                     \
+    int tests_run = 0;                                              \
+    for (it = g_testlist.begin(); it != g_testlist.end(); ++it) {   \
+      /* The test will error-exit if there's a problem. */          \
+      if ((*it)()) {                                                \
+        tests_run++;                                                \
+      }                                                             \
+    }                                                               \
+    fprintf(stderr, "\nPassed %d tests\n\nPASS\n", tests_run);      \
+    return 0;                                                       \
   }
 
 // Note that this macro uses a FlagSaver to keep tests isolated.
-#define TEST(a, b)                                      \
-  struct Test_##a##_##b {                               \
-    Test_##a##_##b() { g_testlist.push_back(&Run); }    \
-    static void Run() {                                 \
-      FlagSaver fs;                                     \
-      fprintf(stderr, "Running test %s/%s\n", #a, #b);  \
-      RunTest();                                        \
-    }                                                   \
-    static void RunTest();                              \
-  };                                                    \
-  static Test_##a##_##b g_test_##a##_##b;               \
+#define TEST(a, b)                                                                                 \
+  struct Test_##a##_##b {                                                                          \
+    Test_##a##_##b() { g_testlist.push_back(&Run); }                                               \
+    static bool Run() {                                                                            \
+      if (!FLAGS_test_filter.empty() && strcasecmp(FLAGS_test_filter.c_str(), (#a "/" #b)) != 0) { \
+        return false;                                                                              \
+      }                                                                                            \
+      FlagSaver fs;                                                                                \
+      fprintf(stderr, "Running test %s/%s\n", #a, #b);                                             \
+      RunTest();                                                                                   \
+      return true;                                                                                 \
+    }                                                                                              \
+    static void RunTest();                                                                         \
+  };                                                                                               \
+  static Test_##a##_##b g_test_##a##_##b;                                                          \
   void Test_##a##_##b::RunTest()
 
 // This is a dummy class that eases the google->opensource transition.

--- a/test/gflags_unittest.cc
+++ b/test/gflags_unittest.cc
@@ -1530,11 +1530,6 @@ TEST(ValidateFlagValueTest, BaseTest) {
     EXPECT_TRUE(ValidateCommandLineOption("test_str1", "second", &err_msg));
     EXPECT_EQ("", err_msg);
   }
-  {
-    string err_msg;
-    EXPECT_TRUE(ValidateCommandLineOption("test_str2", "third", &err_msg));
-    EXPECT_EQ("", err_msg);
-  }
 
   // Bad values
   {
@@ -1594,10 +1589,9 @@ TEST(ValidateFlagValueTest, BaseTest) {
 
 }  // unnamed namespace
 
-static int main(int argc, char **argv) {
-
+static int main(int argc, char** argv) {
   // Run unit tests only if called without arguments, otherwise this program
-  // is used by an "external" usage test
+  // is used by an "external" usage test.
   const bool run_tests = (argc == 1);
 
   // We need to call SetArgv before parsing flags, so our "test" argv will
@@ -1629,10 +1623,13 @@ static int main(int argc, char **argv) {
   MakeTmpdir(&FLAGS_test_tmpdir);
 
   int exit_status = 0;
+  // If the test_filter flag is set, we run a subset of tests.
   if (run_tests || !FLAGS_test_filter.empty()) {
-	  fprintf(stdout, "Running the unit tests now...\n\n"); fflush(stdout);
-	  exit_status = RUN_ALL_TESTS();
-  } else fprintf(stderr, "\n\nPASS\n");
+    fprintf(stdout, "Running the unit tests now...\n\n");
+    fflush(stdout);
+    exit_status = RUN_ALL_TESTS();
+  } else
+    fprintf(stderr, "\n\nPASS\n");
   ShutDownCommandLineFlags();
   return exit_status;
 }

--- a/test/gflags_unittest.cc
+++ b/test/gflags_unittest.cc
@@ -157,7 +157,7 @@ DEFINE_bool(deadlock_if_cant_lock,
             "if locking of registry in validators fails.");
 DEFINE_validator(deadlock_if_cant_lock, DeadlockIfCantLockInValidators);
 
-DEFINE_string(test_filter, "", "Run a single test. Format <TestClass>/<TestCase>");
+DEFINE_string(test_filter, "", "Run a single test. Format <TestClass>[/<TestCase>]");
 
 #define MAKEFLAG(x) DEFINE_int32(test_flag_num##x, x, "Test flag")
 
@@ -1613,4 +1613,3 @@ static int main(int argc, char **argv) {
 int main(int argc, char** argv) {
   return GFLAGS_NAMESPACE::main(argc, argv);
 }
-

--- a/test/gflags_unittest.cc
+++ b/test/gflags_unittest.cc
@@ -1522,6 +1522,8 @@ TEST(FlagsValidator, FlagSaver) {
 
 
 TEST(ValidateFlagValueTest, BaseTest) {
+  EXPECT_EQ("initial", FLAGS_test_str1);
+
   // Valid values
   {
     string err_msg;
@@ -1558,8 +1560,35 @@ TEST(ValidateFlagValueTest, BaseTest) {
     EXPECT_EQ("", err_msg);
   }
 
-  // Undo the flag validator setting
+  // Undo the flag validator
   EXPECT_TRUE(RegisterFlagValidator(&FLAGS_test_flag, NULL));
+
+  // Make sure none of the flags changed due to the validations
+  CommandLineFlagInfo info;
+
+  EXPECT_EQ("initial", FLAGS_test_str1);
+  info = GetCommandLineFlagInfoOrDie("test_str1");
+  EXPECT_EQ("initial", info.current_value);
+  EXPECT_EQ("initial", info.default_value);
+  EXPECT_TRUE(info.is_default);
+
+  EXPECT_EQ("initial", FLAGS_test_str2);
+  info = GetCommandLineFlagInfoOrDie("test_str2");
+  EXPECT_EQ("initial", info.current_value);
+  EXPECT_EQ("initial", info.default_value);
+  EXPECT_TRUE(info.is_default);
+
+  EXPECT_DOUBLE_EQ(-1, FLAGS_test_double);
+  info = GetCommandLineFlagInfoOrDie("test_double");
+  EXPECT_EQ("-1", info.current_value);
+  EXPECT_EQ("-1", info.default_value);
+  EXPECT_TRUE(info.is_default);
+
+  EXPECT_EQ(-1, FLAGS_test_flag);
+  info = GetCommandLineFlagInfoOrDie("test_flag");
+  EXPECT_EQ("-1", info.current_value);
+  EXPECT_EQ("-1", info.default_value);
+  EXPECT_TRUE(info.is_default);
 }
 
 

--- a/test/gflags_unittest.cc
+++ b/test/gflags_unittest.cc
@@ -1613,3 +1613,4 @@ static int main(int argc, char **argv) {
 int main(int argc, char** argv) {
   return GFLAGS_NAMESPACE::main(argc, argv);
 }
+


### PR DESCRIPTION
Adding `ValidateCommandLineOption` that validates a flag value without actually setting it. This will be useful to prevent processes crashes that currently arises from setting incorrect values, by validating the flag for use before setting it.

Test improvement:
Added `test_filter` flag for filtering and running a single unit test.

Test Plan:
> ./build_and_test.sh; _build/bin/gflags_unittest --test_filter ValidateFlagValueTest/BaseTest
> 
> Running the unit tests now...
> 
> Running test ValidateFlagValueTest/BaseTest
> test_flag isn't 5!
> 
> Passed 1 tests
> 
> PASS